### PR TITLE
Delete drake.models only if it exists.

### DIFF
--- a/directive.js
+++ b/directive.js
@@ -35,7 +35,9 @@ function register (angular) {
         var containerIndex = drake.containers.indexOf(container);
         if (containerIndex >= 0) {
           drake.containers.splice(containerIndex, 1);
-          drake.models.splice(containerIndex, 1);
+          if (drake.models && drake.models[containerIndex]) {
+            drake.models.splice(containerIndex, 1);
+          }
         }
       });
 


### PR DESCRIPTION
Apparently drake sometimes does not create a model list to match the containers list. This just adds a simple check to make sure models exist before attempting to splice them.